### PR TITLE
Fix WeeklyDays In-place Array Transform

### DIFF
--- a/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
@@ -744,7 +744,7 @@ function New-ZoomMeeting {
             }
             
             if ($PSBoundParameters.ContainsKey('WeeklyDays')) {
-                $WeeklyDays[$WeeklyDays.IndexOf($_)] | ForEach-Object {
+                $WeeklyDays | ForEach-Object {
                     #Loops through each day and changes it because this parameter is an array
                     $WeeklyDays[$WeeklyDays.IndexOf($_)] = switch ($_) {
                         'Sunday'    { 1 }


### PR DESCRIPTION
The in-place transformation of $WeeklyDays from an array of English language weekdays to the required integer representation was not working correctly, and would only transform some of the array elements. The request would still succeed, but without all of the requested days.