### PR TITLE
Fix MuteUponEntry Option

### DIFF
--- a/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
@@ -851,7 +851,7 @@ function New-ZoomMeeting {
             'participant_video'              = 'ParticipantVideo'
             'in_meeting'                     = 'INMeeting'
             'join_before_host'               = 'JoinBeforeHost'
-            'mute_upon_entry'                = 'Mutentry'
+            'mute_upon_entry'                = 'MuteUponEntry'
             'registration_type'              = 'RegistrationType'
             'use_pmi'                        = 'UsePMI'
             'waiting_room'                   = 'WaitingRoom'

--- a/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
@@ -490,7 +490,7 @@ function Update-ZoomMeeting {
         'cn_meeting'              = 'CNMeeting'
         'in_meeting'              = 'INMeeting'
         'join_before_host'        = 'JoinBeforeHost'
-        'mute_upon_entry'         = 'Mutentry'
+        'mute_upon_entry'         = 'MuteUponEntry'
         'watermark'               = 'Watermark'
         'use_pmi'                 = 'UsePMI'
         'approval_type'           = 'ApprovalType'


### PR DESCRIPTION
MuteUponEntry is erroneously written as 'Mutentry' which always passes the option for MuteUponEntry when creating or updating a meeting as $false. This pull makes it pass the real input (confirmed via testing with the Zoom API).